### PR TITLE
ユーザー登録確認ページのビュー作成

### DIFF
--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -1,0 +1,6 @@
+.main-view {
+  width: 700px;
+  .main-confimation {
+    background-color: #fff;
+  }
+}

--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -1,6 +1,112 @@
 .main-view {
   width: 700px;
+  box-sizing: border-box;
   .main-confimation {
     background-color: #fff;
+    &__head {
+      font-size: 24px;
+      padding: 8px 24px;
+      border-bottom: 1px solid #f5f5f5;
+      text-align: center;
+      line-height: 1.4;
+      font-weight: 600;
+    }
+    &__form {
+      border-top: 1px solid #f5f5f5;
+      padding: 64px;
+
+      .form-description {
+        display: block;
+        margin: 8px 0 0;
+        line-height: 1.5;
+        font-size: 14px;
+        font-weight: lighter;
+      }
+      .text-right {
+        margin: 8px 0 0;
+        line-height: 1.5;
+        text-align: right;
+
+        a {
+          font-size: 14px;
+          color: #0099e8;
+          text-decoration: none;
+        }
+        a:hover {
+          opacity: 0.6;
+          text-decoration: underline;
+        }
+      }
+      .form-group {
+        margin: 40px 0 0;
+        label.label {
+          font-weight: 600;
+          display: block;
+          font-size: 14px;
+          color: #333;
+          span.arbitrary {
+            background-color: #ccc;
+            margin-left: 8px;
+            font-size: 12px;
+            color: #fff;
+            padding: 2px 4px;
+            border-radius: 2px;
+            vertical-align: top;
+            font-weight: lighter;
+          }
+        }
+        
+        p {
+          margin: 8px 0 0;
+          line-height: 1.5;
+          font-size: 14px;
+        }
+        .input-default {
+          width: 94%;
+          margin: 8px 0 0;
+          padding: 10px 16px 8px;
+          border-radius: 4px;
+          border: 1px solid #ccc;
+          line-height: 1.5;
+          font-size: 16px;
+        }
+        .select-default {
+          width: 100%;
+          margin: 8px 0 0;
+          padding: 10px 16px 8px;
+          border-radius: 4px;
+          border: 1px solid #ccc;
+          line-height: 1.5;
+          font-size: 16px;
+          height: 48px;
+          background-color: #fff;
+        }
+
+        // 機能実装の際に上のselect-defaultと入れ替わる予定
+        // .collection_select {
+        //   width: 100%;
+        //   margin: 8px 0 0;
+        //   padding: 10px 16px 8px;
+        //   border-radius: 4px;
+        //   border: 1px solid #ccc;
+        //   line-height: 1.5;
+        //   font-size: 16px;
+        //   height: 48px;
+        //   background-color: #fff;
+        // }
+      }
+
+      .btn-default {
+        margin-top: 40px;
+        background-color: #ea352d;
+        border: 1px solid #ea352d;
+        color: #fff;
+        display: block;
+        width: 100%;
+        font-size: 14px;
+        line-height: 48px;
+        cursor: pointer;
+      }
+    }
   }
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,11 @@
 class UsersController < ApplicationController
 
   def show
-    
   end  
+
+  def edit
+    @user = User.find(params[:id])
+  end
 
   def sign_up_user_info
     reset_session

--- a/app/views/items/hidden.html.haml
+++ b/app/views/items/hidden.html.haml
@@ -21,6 +21,7 @@ picture
 
 users
 %p= link_to "users#show", user_path(id: 1)
+%p= link_to "users#edit", edit_user_path(id:1)
 item
 %p= link_to "items#index", items_path
 %p= link_to "items#show", item_path(id: 1)

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,21 @@
+.container
+  = render partial: 'items/header'
+
+  = render partial: 'devise/registrations/bread-crumbs'
+
+  .main-box
+    
+    = render partial: 'devise/registrations/side-bar'
+
+    .main-view
+      .main-confimation
+        %h2.main-confimation__head
+          本人情報の登録
+
+
+
+
+
+  = render partial: 'items/bottom'
+
+  = render partial: 'items/sell-btn'

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -12,6 +12,90 @@
         %h2.main-confimation__head
           本人情報の登録
 
+        .main-confimation__form
+          .form-description
+            お客様の本人情報をご登録ください。
+            %br
+            登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+
+          .text-right
+            = link_to "#" do
+              本人確認書類のアップロードについて
+              %span
+              %i.fas.fa-chevron-right
+                
+          .form-group
+            %label.label
+              お名前
+            %p 
+              長宗我部 元親
+              -# 以下、サーバーサイド実装でコメントアウト外す %inputと%buttonは入れ替えする予定
+              -# = current_user.lastname
+              -# = current_user.firstname
+          .form-group
+            %label.label
+              お名前カナ
+            %p
+              チョウソカベ モトチカ
+              -# = current_user.lastname_kana
+              -# = current_user.firstname_kana
+          .form-group
+            %label.label
+              生年月日
+            %p
+              1599/07/11
+              -# = user.birthday.strftime('%Y/%m/%d')
+
+          .form-group
+            %label.label
+              郵便番号
+              %span.arbitrary
+                任意
+            %input.input-default{name: "zip_code", placeholder: "例）1234567", type: "text", value: ""}/
+            -# = f.text_field :zip_code, class: "input-default", placeholder: "例）1234567"
+
+          .form-group
+            %label.label
+              都道府県
+              %span.arbitrary
+                任意
+            %select.select-default
+              %option{value: ""} --
+            -# = f.collection_select :id, Prefecture.all, :id, :name, {prompt: '---'}, class: "prefecture_id"
+
+          .form-group
+            %label.label
+              市区町村
+              %span.arbitrary
+                任意
+            %input.input-default{name: "city", placeholder: "例) 横浜市緑区", type: "text", value: ""}/
+            -# = f.text_field :city, class: "input-default", placeholder: "例）横浜市緑区"
+
+          .form-group
+            %label.label
+              番地
+              %span.arbitrary
+                任意
+            %input.input-default{name: "address1", placeholder: "例) 青山1−1−1", type: "text", value: ""}/
+            -# = f.text_field :address1, class: "input-default", placeholder: "例）青山1-1-1"
+
+          .form-group
+            %label.label
+              建物名
+              %span.arbitrary
+                任意
+            %input.input-default{name: "address2", placeholder: "例) 柳ビル103", type: "text", value: ""}/
+            -# = f.text_field :address2, class: "input-default", placeholder: "例）柳ビル103"
+
+          %button.btn-default{type: "submit"} 登録する
+          -# = f.submit '登録する', class: 'btn-default'
+
+
+          .form-group.text-right
+            = link_to "#" do
+              本人情報の登録について
+              %span
+              %i.fas.fa-chevron-right
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   root 'items#index'
   get "items/hidden" => "items#hidden"
   
-  resources :users, only: [:show]
+  resources :users, only: [:show, :edit]
 
   resources :pictures, only: [:new, :create]
   resources :items, only: [:index, :show, :new]


### PR DESCRIPTION
[What]
ログインユーザーの登録確認ページのビュー作成

[Why]
ヘッダー、サイドバー、フッターは部分テンプレート
都道府県のセレクトボックスはactive_hashを利用、現状は表示するためにセレクトボックス、
機能実装時にすぐに変えられるようにコメントアウトにて追記済み
その他、current_userの情報をすぐに呼び出せるようにコメントアウトにて記述入ってます。
![screencapture-localhost-3000-users-1-edit-2019-09-05-18_14_11](https://user-images.githubusercontent.com/53419840/64329257-eeba9880-d009-11e9-96f4-7e8e4c79c476.png)
