### PR TITLE
ユーザープロフィール　ビュー作成

### DIFF
--- a/app/assets/stylesheets/users/profile.scss
+++ b/app/assets/stylesheets/users/profile.scss
@@ -26,7 +26,6 @@
             height: 60px;
             border-radius: 50%;
             display: block;
-            // margin-left: 200px;
           }
           &__name {
             line-height: 60px;

--- a/app/assets/stylesheets/users/profile.scss
+++ b/app/assets/stylesheets/users/profile.scss
@@ -11,5 +11,60 @@
       line-height: 1.4;
       font-weight: 600;
     }
+    &__form {
+      box-sizing: border-box;
+      .profile-icon {
+        padding: 72px 16px 24px;
+        background-image: url("https://www.mercari.com/jp/assets/img/mypage/user-bg.jpg?45085161");
+        &__user {
+          display: flex;
+          width: 300px;
+          margin: 0 auto;
+          &__image {
+            overflow: hidden;
+            width: 60px;
+            height: 60px;
+            border-radius: 50%;
+            display: block;
+            // margin-left: 200px;
+          }
+          &__name {
+            line-height: 60px;
+            display: block;
+            .profile-icon-name {
+              width: 200px;
+              font-size: 16px;
+              margin: 0 0 0 8px;
+              height: 25px;
+              padding: 10px 16px 8px;
+              border-radius: 4px;
+              border: 1px solid #ccc;
+            }
+          }
+        }
+      }
+      .profile-content {
+        padding: 40px 16px;
+        .profile-box {
+          min-height: 216px;
+          display: block;
+          width: 97%;
+          padding: 10px;
+          border: 1px solid #ccc;
+          overflow: auto;
+        }
+        .profile-box-submit {
+          margin-top: 40px;
+          background-color: #ea352d;
+          border: 1px solid #ea352d;
+          color: #fff;
+          display: block;
+          width: 100%;
+          font-size: 14px;
+          line-height: 48px;
+          cursor: pointer;
+        }
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/users/profile.scss
+++ b/app/assets/stylesheets/users/profile.scss
@@ -1,0 +1,15 @@
+.main-view {
+  width: 700px;
+  box-sizing: border-box;
+  .main-profile {
+    background-color: #fff;
+    &__head {
+      font-size: 24px;
+      padding: 8px 24px;
+      border-bottom: 1px solid #f5f5f5;
+      text-align: center;
+      line-height: 1.4;
+      font-weight: 600;
+    }
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,10 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
+  def profile
+    @user = User.find(params[:id])
+  end
+
   def sign_up_user_info
     reset_session
     @user = User.new  

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,15 +1,11 @@
 class UsersController < ApplicationController
-  before_action :set_current_user
+  before_action :set_user, only: [:edit, :profile]
 
   def show
   end  
-
-  def edit
+  
+  def set_user
     @user = User.find(params[:id])
-  end
-
-  def profile
-    @current_user = User.find(params[:id])
   end
 
   def sign_up_user_info

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
   end  
 
   def edit
+    @user = User.find(params[:id])
   end
 
   def sign_up_user_info

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,10 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: [:edit, :profile]
+  before_action :set_user, only: [:profile]
 
   def show
   end  
-  
-  def set_user
-    @user = User.find(params[:id])
+
+  def edit
   end
 
   def sign_up_user_info
@@ -74,5 +73,9 @@ class UsersController < ApplicationController
     # params.require(:shipping).permit(:first_name_kanji, :last_name_kanji, :first_name_kana, :last_name_kana, :zipcode, :pref, :city, :adress, :building, :phone)
     # params.require(:shipping).permit(:zipcode)[:zipcode].delete!("-")
     params.require(:shipping).permit(:zipcode, :pref, :city, :address, :building, :phone).merge(user_id: session[:id])
+  end
+
+  def set_user
+    @user = User.find(params[:id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :set_current_user
 
   def show
   end  
@@ -8,7 +9,7 @@ class UsersController < ApplicationController
   end
 
   def profile
-    @user = User.find(params[:id])
+    @current_user = User.find(params[:id])
   end
 
   def sign_up_user_info

--- a/app/views/items/hidden.html.haml
+++ b/app/views/items/hidden.html.haml
@@ -22,6 +22,7 @@ picture
 users
 %p= link_to "users#show", user_path(id: 1)
 %p= link_to "users#edit", edit_user_path(id:1)
+%p= link_to "users#profile", profile_user_path(id:1)
 item
 %p= link_to "items#index", items_path
 %p= link_to "items#show", item_path(id: 1)

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -1,0 +1,19 @@
+.container
+  = render partial: 'items/header'
+
+  = render partial: 'devise/registrations/bread-crumbs'
+
+  .main-box
+    
+    = render partial: 'devise/registrations/side-bar'
+
+    .main-view
+      .main-profile
+        .main-profile__head
+          プロフィール
+
+
+
+  = render partial: 'items/bottom'
+
+  = render partial: 'items/sell-btn'

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -8,11 +8,29 @@
     = render partial: 'devise/registrations/side-bar'
 
     .main-view
+      -# コメントアウトは機能実装用に暫定で用意、名前とか注意してください
+      -# = form_for @user do |f|
       .main-profile
         .main-profile__head
           プロフィール
+        .main-profile__form
+          .profile-icon
+            .profile-icon__user
+              .profile-icon__user__image
+                = image_tag 'https:////static.mercdn.net/images/member_photo_noimage_thumb.png', height: "60px" , width: "60px"
+                -# = image_tag @user.icon_image.to_s, class: "icon_image", width: "60px", height: "60px"
 
+              .profile-icon__user__name
+                %input.profile-icon-name{placeholder: ""}
+                -# = f.text_field :nickname, value: @user.nickname, placeholder: ""
 
+          .profile-content
+            .profile-content__text-area
+              =  text_area :profile, :profile, class: "profile-box",placeholder: "例) 私の名前は長宗我部 元親、あだ名はモッチン、出品は主に戦に使用したものがメインになるでござりまする。最近はVRに興味があるでござるよ。"
+              -# = f.text_area :profile, :profile, class: "profile-box",placeholder: "例) 私の名前は長宗我部 元親、あだ名はモッチン、出品は主に戦に使用したものがメインになるでござりまする。最近はVRに興味があるでござるよ。"
+
+            %button.profile-box-submit{type: "submit"} 変更する
+            -# = f.submit '変更する', class: 'profile-box-submit'
 
   = render partial: 'items/bottom'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,11 @@ Rails.application.routes.draw do
   root 'items#index'
   get "items/hidden" => "items#hidden"
   
-  resources :users, only: [:show, :edit]
+  resources :users, only: [:show, :edit] do
+    member do
+      get  :profile
+    end
+  end
 
   resources :pictures, only: [:new, :create]
   resources :items, only: [:index, :show, :new]


### PR DESCRIPTION
[What]
ユーザーのプロフィール画面の作成


[Why]
ニックネームとコメントの変更も可能なページ
部分テンプレートにヘッダーとサイドバー、フッター利用
サーバー側と紐付けできるよう、暫定でuser_controllerに関する記述をコメントアウトにて記述
![screencapture-localhost-3000-users-1-profile-2019-09-06-14_10_08](https://user-images.githubusercontent.com/53419840/64402705-c9cd3080-d0b0-11e9-9209-90d0824d8253.png)
